### PR TITLE
feat: Implement CookieManager

### DIFF
--- a/src/main/java/org/team14/webty/common/cookies/CookieManager.java
+++ b/src/main/java/org/team14/webty/common/cookies/CookieManager.java
@@ -1,4 +1,54 @@
 package org.team14.webty.common.cookies;
 
+import java.util.Arrays;
+import java.util.Optional;
+
+import org.springframework.http.ResponseCookie;
+import org.team14.webty.common.enums.TokenType;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 public class CookieManager {
+	private final HttpServletResponse response;
+	private final HttpServletRequest request;
+
+	public String getCookieByTokenType(TokenType tokenType) {
+		return Optional
+			.ofNullable(request.getCookies())
+			.filter(cookies -> cookies.length > 0)
+			.stream()
+			.flatMap(Arrays::stream)
+			.filter(cookie -> cookie.getName().equals(tokenType.getName()))
+			.map(Cookie::getValue)
+			.findFirst()
+			.orElse(null);
+	}
+
+	public void setCookie(TokenType tokenType, String token, long expiration) {
+		ResponseCookie cookie = ResponseCookie.from(tokenType.getName(), token)
+			.maxAge(expiration)
+			.domain("localhost")
+			.path("/")
+			.secure(true)
+			.httpOnly(true)
+			.build();
+
+		response.addHeader("Set-Cookie", cookie.toString());
+	}
+
+	public void removeCookie(TokenType tokenType) {
+		ResponseCookie cookie = ResponseCookie.from(tokenType.getName(), "")
+			.maxAge(0)
+			.domain("localhost")
+			.path("/")
+			.secure(true)
+			.httpOnly(true)
+			.build();
+
+		response.addHeader("Set-Cookie", cookie.toString());
+	}
 }

--- a/src/main/java/org/team14/webty/common/enums/TokenType.java
+++ b/src/main/java/org/team14/webty/common/enums/TokenType.java
@@ -1,0 +1,15 @@
+package org.team14.webty.common.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum TokenType {
+	ACCESS_TOKEN("ACCESS_TOKEN"),
+	REFRESH_TOKEN("REFRESH_TOKEN");
+
+	private final String name;
+
+	TokenType(String name) {
+		this.name = name;
+	}
+}

--- a/src/main/java/org/team14/webty/security/policy/ExpirationPolicy.java
+++ b/src/main/java/org/team14/webty/security/policy/ExpirationPolicy.java
@@ -1,0 +1,14 @@
+package org.team14.webty.security.policy;
+
+public class ExpirationPolicy {
+	private static final long REFRESH_TOKEN_EXPIRATION_TIME = 3600000; // 1 hour in milliseconds
+	private static final long ACCESS_TOKEN_EXPIRATION_TIME = 3600000; // 1 hour in milliseconds
+
+	public static long getRefreshTokenExpirationTime() {
+		return REFRESH_TOKEN_EXPIRATION_TIME;
+	}
+
+	public static long getAccessTokenExpirationTime() {
+		return ACCESS_TOKEN_EXPIRATION_TIME;
+	}
+}

--- a/src/main/java/org/team14/webty/security/token/JwtManager.java
+++ b/src/main/java/org/team14/webty/security/token/JwtManager.java
@@ -1,4 +1,4 @@
 package org.team14.webty.security.token;
 
-public class JwtUtil {
+public class JwtManager {
 }

--- a/src/main/java/org/team14/webty/security/token/RefreshToken.java
+++ b/src/main/java/org/team14/webty/security/token/RefreshToken.java
@@ -1,4 +1,21 @@
 package org.team14.webty.security.token;
 
-public class RefreshToken {
+import java.io.Serializable;
+
+import lombok.Getter;
+
+@Getter
+public class RefreshToken implements Serializable {
+
+	private Long refreshTokenId;
+	private String userId; // WebtyUser userId
+	private String token;
+
+	public RefreshToken() {
+	}
+
+	public RefreshToken(String userId, String token) {
+		this.userId = userId;
+		this.token = token;
+	}
 }


### PR DESCRIPTION
- CookieManager 구현
    - getCookieByTokenType: 원하는 토큰이 들어있는 쿠키 제공
    - setCookie: 토큰을 받아 쿠키 설정
    - removeCookie: 쿠키 제거 (= 토큰 없는 빈 쿠키 설정)

- JwtUtil -> JwtManager
    - `CookieManager`와 통일감을 주기 위해 변경함

- 기타 새로운 클래스 생성
    - TokenType: 토큰 종류(엑세스, 리프레쉬) 문자열을 저장하는 enum.
    - ExpirationPolicy: 토큰 별 만료 시간을 저장하는 클래스.
    - RefreshToken: 리프레쉬 토큰 entity
        - `redis`에 저장하기 위해 `Serializable`으로 구현함

close #12