### PR TITLE
typo-fix: 재귀적 하위댓글 조회기능 오류를 네이티브 쿼리로 변경

### DIFF
--- a/src/main/java/org/team14/webty/reviewComment/repository/ReviewCommentRepository.java
+++ b/src/main/java/org/team14/webty/reviewComment/repository/ReviewCommentRepository.java
@@ -28,15 +28,19 @@ public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Lo
 		"ORDER BY rc.createdAt ASC")
 	List<ReviewComment> findRootComments(@Param("reviewId") Long reviewId);
 
-	// 특정 댓글의 모든 하위 댓글 조회 (재귀적으로) //에러나서 임시 주석처리
-	// @Query("WITH RECURSIVE CommentHierarchy AS (" +
-	// 	"  SELECT c.* FROM review_comment c WHERE c.comment_id = :commentId " +
-	// 	"  UNION ALL " +
-	// 	"  SELECT c.* FROM review_comment c " +
-	// 	"  INNER JOIN CommentHierarchy ch ON c.parent_id = ch.comment_id" +
-	// 	") " +
-	// 	"SELECT * FROM CommentHierarchy")
-	// List<ReviewComment> findAllChildComments(@Param("commentId") Long commentId);
+	// 특정 댓글의 모든 하위 댓글 조회 (재귀적으로)
+	@Query(value = """
+		WITH RECURSIVE CommentHierarchy AS (
+			SELECT * FROM review_comment 
+			WHERE comment_id = :commentId 
+			UNION ALL 
+			SELECT c.* FROM review_comment c 
+			INNER JOIN CommentHierarchy ch ON c.parent_id = ch.comment_id
+		) 
+		SELECT * FROM CommentHierarchy
+		""", 
+		nativeQuery = true)
+	List<ReviewComment> findAllChildComments(@Param("commentId") Long commentId);
 
 	// 특정 depth의 댓글만 조회
 	@Query("SELECT rc FROM ReviewComment rc WHERE rc.review.reviewId = :reviewId AND rc.depth = :depth")


### PR DESCRIPTION
Close #63 
#36 에서 발생한 오류를 보완했습니다.
@Dia218 님께서 오류를 확인해주셔서, 네이티브 쿼리로 변경해보니 작동하네요.
@ReviewCommentRepository.java 에서  특정 댓글의 하위 댓글을 재귀적으로 조회하는 기능을 담당하는 코드에 오류가 있어 수정합니다.

**원래코드**
```java
	 @Query("WITH RECURSIVE CommentHierarchy AS (" +
	 	"  SELECT c.* FROM review_comment c WHERE c.comment_id = :commentId " +
		"  UNION ALL " +
		"  SELECT c.* FROM review_comment c " +
	 	"  INNER JOIN CommentHierarchy ch ON c.parent_id = ch.comment_id" +
	 	") " +
	 	"SELECT * FROM CommentHierarchy")
	 List<ReviewComment> findAllChildComments(@Param("commentId") Long commentId);
```
**수정코드**
```java
@Query(value = """
		WITH RECURSIVE CommentHierarchy AS (
			SELECT * FROM review_comment 
			WHERE comment_id = :commentId 
			UNION ALL 
			SELECT c.* FROM review_comment c 
			INNER JOIN CommentHierarchy ch ON c.parent_id = ch.comment_id
		) 
		SELECT * FROM CommentHierarchy
		""", 
		nativeQuery = true)
	List<ReviewComment> findAllChildComments(@Param("commentId") Long commentId);
```