### PR TITLE
feat: 웹툰 검색기능 추가

### DIFF
--- a/src/main/java/org/team14/webty/common/dto/PageDto.java
+++ b/src/main/java/org/team14/webty/common/dto/PageDto.java
@@ -1,4 +1,22 @@
 package org.team14.webty.common.dto;
 
-public class PageDto {
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageDto<T> {
+	private List<T> content;
+	private int currentPage;
+	private int totalPages;
+	private long totalElements;
+	private boolean hasNext;
+	private boolean hasPrevious;
+	private boolean isLast;
 }

--- a/src/main/java/org/team14/webty/common/mapper/PageMapper.java
+++ b/src/main/java/org/team14/webty/common/mapper/PageMapper.java
@@ -1,0 +1,18 @@
+package org.team14.webty.common.mapper;
+
+import org.springframework.data.domain.Page;
+import org.team14.webty.common.dto.PageDto;
+
+public class PageMapper {
+	public static <T> PageDto<T> toPageDto(Page<T> page) {
+		return PageDto.<T>builder()
+			.content(page.getContent())
+			.currentPage(page.getNumber())
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.hasNext(page.hasNext())
+			.hasPrevious(page.hasPrevious())
+			.isLast(page.isLast())
+			.build();
+	}
+}

--- a/src/main/java/org/team14/webty/security/authentication/CustomAuthenticationFilter.java
+++ b/src/main/java/org/team14/webty/security/authentication/CustomAuthenticationFilter.java
@@ -36,7 +36,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
 		String requestURI = request.getRequestURI();
 
 		List<String> excludePrefixes = List.of( // 여기에 다른 페이지는 추가하지 않습니다
-			"/login"
+			"/login", "/webtoons"
 		);
 
 		return excludePrefixes.stream()

--- a/src/main/java/org/team14/webty/security/config/SecurityConfig.java
+++ b/src/main/java/org/team14/webty/security/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
 					.requestMatchers(HttpMethod.GET, "/webtoons/{id:\\d+}").permitAll()
-					.requestMatchers(HttpMethod.GET, "/webtoons").permitAll()
+					.requestMatchers(HttpMethod.GET, "/webtoons/search").permitAll()
 					.requestMatchers("/logout/kakao", "/user-profile", "/user/**",
 						"/favorite/**") // 로그인 해야 접속 가능한 페이지 목록
 					.authenticated()
@@ -51,7 +51,7 @@ public class SecurityConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() { // 스프링 시큐리티를 무시할 페이지 목록 ( = 로그인이 필요없는 페이지 목록)
 		return web -> web.ignoring().requestMatchers(
-			"h2-console/**", "/error", "/webtoon",
+			"h2-console/**", "/error",
 			"/favorite" // 테스트 이후 제거할 목록
 		);
 	}

--- a/src/main/java/org/team14/webty/webtoon/controller/WebtoonController.java
+++ b/src/main/java/org/team14/webty/webtoon/controller/WebtoonController.java
@@ -1,12 +1,17 @@
 package org.team14.webty.webtoon.controller;
 
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.team14.webty.common.dto.PageDto;
+import org.team14.webty.common.mapper.PageMapper;
 import org.team14.webty.webtoon.dto.WebtoonDetailDto;
+import org.team14.webty.webtoon.dto.WebtoonSearchRequest;
 import org.team14.webty.webtoon.entity.Webtoon;
+import org.team14.webty.webtoon.enumerate.Platform;
 import org.team14.webty.webtoon.mapper.WebtoonDetailMapper;
 import org.team14.webty.webtoon.service.WebtoonService;
 
@@ -20,14 +25,28 @@ import lombok.RequiredArgsConstructor;
 public class WebtoonController {
 	private final WebtoonService webtoonService;
 
-	@GetMapping("/fetch")
-	public void fetchWebtoons() {
-		webtoonService.saveWebtoons();
-	}
+	// @GetMapping("/fetch") // 초기화 할 때만 사용
+	// public void fetchWebtoons() {
+	// 	webtoonService.saveWebtoons();
+	// }
 
 	@GetMapping("/{id}")
 	public ResponseEntity<WebtoonDetailDto> findWebtoon(@Valid @Min(1) @PathVariable Long id){
 		Webtoon webtoon = webtoonService.findWebtoon(id);
 		return ResponseEntity.ok(WebtoonDetailMapper.toDto(webtoon));
+	}
+
+	@GetMapping("/search")
+	public ResponseEntity<PageDto<WebtoonDetailDto>> searchWebtoons(@Valid WebtoonSearchRequest request) {
+		Page<WebtoonDetailDto> webtoons = webtoonService.searchWebtoons(
+			request.getWebtoonName(),
+			request.getPlatform() != null ? Platform.fromString(request.getPlatform()) : null,
+			request.getAuthors(),
+			request.getFinished(),
+			request.getPage(),
+			request.getSize(),
+			request.getSortBy(),
+			request.getSortDirection()).map(WebtoonDetailMapper::toDto);
+		return ResponseEntity.ok(PageMapper.toPageDto(webtoons));
 	}
 }

--- a/src/main/java/org/team14/webty/webtoon/dto/WebtoonSearchRequest.java
+++ b/src/main/java/org/team14/webty/webtoon/dto/WebtoonSearchRequest.java
@@ -1,0 +1,36 @@
+package org.team14.webty.webtoon.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class WebtoonSearchRequest {
+	@Size(max = 100)
+	private String webtoonName;
+
+	@Pattern(regexp = "^(NAVER|KAKAO_PAGE)?$", message = "Platform must be either NAVER or KAKAO_PAGE")
+	private String platform;
+
+	@Size(max = 100)
+	private String authors;
+
+	private Boolean finished;
+
+	@Min(0)
+	private int page = 0;
+
+	@Min(1) @Max(100)
+	private int size = 10;
+
+	@Pattern(regexp = "^(WEBTOON_NAME|AUTHORS|PLATFORM|FINISHED)$",
+		message = "Sort by must be one of: WEBTOON_NAME, PLATFORM, AUTHORS, FINISHED")
+	private String sortBy = "WEBTOON_NAME";
+
+	@Pattern(regexp = "^(asc|desc)$", message = "Sort direction must be either asc or desc")
+	private String sortDirection = "asc";
+}

--- a/src/main/java/org/team14/webty/webtoon/enumerate/WebtoonSort.java
+++ b/src/main/java/org/team14/webty/webtoon/enumerate/WebtoonSort.java
@@ -1,0 +1,24 @@
+package org.team14.webty.webtoon.enumerate;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WebtoonSort {
+	WEBTOON_NAME("webtoonName"),
+	PLATFORM("platform"),
+	AUTHORS("authors"),
+	FINISHED("finished");
+
+	private final String field;
+
+	public static Optional<WebtoonSort> fromString(String value) {
+		return Arrays.stream(WebtoonSort.values())
+			.filter(sort -> sort.name().equalsIgnoreCase(value))
+			.findFirst();
+	}
+}

--- a/src/main/java/org/team14/webty/webtoon/repository/WebtoonRepository.java
+++ b/src/main/java/org/team14/webty/webtoon/repository/WebtoonRepository.java
@@ -1,9 +1,25 @@
 package org.team14.webty.webtoon.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import org.team14.webty.webtoon.entity.Webtoon;
+import org.team14.webty.webtoon.enumerate.Platform;
 
 @Repository
 public interface WebtoonRepository extends JpaRepository<Webtoon, Long> {
+
+	@Query("SELECT w FROM Webtoon w " +
+		"WHERE (:webtoonName IS NULL OR w.webtoonName LIKE %:webtoonName%) " +
+		"AND (:platform IS NULL OR w.platform = :platform) " +
+		"AND (:authors IS NULL OR w.authors LIKE %:authors%) " +
+		"AND (:finished IS NULL OR w.finished = :finished)")
+	Page<Webtoon> searchWebtoons(@Param("webtoonName") String webtoonName,
+		@Param("platform") Platform platform,
+		@Param("authors") String authors,
+		@Param("finished") Boolean finished,
+		Pageable pageable);
 }

--- a/src/main/java/org/team14/webty/webtoon/service/WebtoonService.java
+++ b/src/main/java/org/team14/webty/webtoon/service/WebtoonService.java
@@ -6,6 +6,10 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -15,6 +19,7 @@ import org.springframework.web.client.RestTemplate;
 import org.team14.webty.webtoon.api.WebtoonPageApiResponse;
 import org.team14.webty.webtoon.entity.Webtoon;
 import org.team14.webty.webtoon.enumerate.Platform;
+import org.team14.webty.webtoon.enumerate.WebtoonSort;
 import org.team14.webty.webtoon.mapper.WebtoonApiResponseMapper;
 import org.team14.webty.webtoon.repository.WebtoonRepository;
 
@@ -150,5 +155,17 @@ public class WebtoonService {
 	public Webtoon findWebtoon(Long id) {
 		return webtoonRepository.findById(id)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 웹툰 ID 입니다."));
+	}
+
+	public Page<Webtoon> searchWebtoons(String webtoonName, Platform platform, String authors, Boolean finished,
+		int page, int size, String sortBy, String sortDirection) {
+		Sort.Direction direction = sortDirection.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+		String sortField = WebtoonSort.fromString(sortBy)
+			.map(WebtoonSort::getField)
+			.orElse(WebtoonSort.WEBTOON_NAME.getField()); // 기본 정렬: WEBTOON_NAME
+
+		Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+
+		return webtoonRepository.searchWebtoons(webtoonName, platform, authors, finished, pageable);
 	}
 }


### PR DESCRIPTION
웹툰 검색기능 구현했습니다.
웹툰명, 작가명, 플랫폼, 완결여부에 따른 검색기능을 지원하며, 정렬도 가능합니다.
PageDto<T> 추가하였습니다. 그에따른 Mapper 추가하였습니다.

그 시큐리티를 안건드려고 했는데 계속 401응답이 나와서
CustomAuthenticationFilter에 추가하지 말라고 적혀있는데 불구하고 적게 되었습니다

```
@Bean
	public WebSecurityCustomizer webSecurityCustomizer() { // 스프링 시큐리티를 무시할 페이지 목록 ( = 로그인이 필요없는 페이지 목록)
		return web -> web.ignoring().requestMatchers(
			"h2-console/**", "/error",
			"/favorite" // 테스트 이후 제거할 목록
		);
	}
```

여기에 추가해도 계속 필터에서 걸려서 401이 나옵니다. 그래서 추가를 했습니다.

웹툰 fetch의 경우 서비스 도중에 호출할 일이 없기때문에 주석처리했습니다.

close #56 