### PR TITLE
refactor: UserDetails Principal, AuthWebtyUserProvider Implement

### DIFF
--- a/src/main/java/org/team14/webty/security/authentication/AuthWebtyUserProvider.java
+++ b/src/main/java/org/team14/webty/security/authentication/AuthWebtyUserProvider.java
@@ -1,0 +1,20 @@
+package org.team14.webty.security.authentication;
+
+import java.nio.file.attribute.UserPrincipalNotFoundException;
+
+import org.springframework.stereotype.Component;
+import org.team14.webty.user.entity.WebtyUser;
+
+@Component
+public class AuthWebtyUserProvider {
+	public WebtyUser getAuthenticatedWebtyUser(WebtyUserDetails webtyUserDetails) {
+		if (webtyUserDetails == null || webtyUserDetails.getWebtyUser() == null) {
+			try { // 예외 처리 정리해야함
+				throw new UserPrincipalNotFoundException("로그인이 필요합니다.");
+			} catch (UserPrincipalNotFoundException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return webtyUserDetails.getWebtyUser();
+	}
+}

--- a/src/main/java/org/team14/webty/security/authentication/WebtyUserDetailsService.java
+++ b/src/main/java/org/team14/webty/security/authentication/WebtyUserDetailsService.java
@@ -3,8 +3,6 @@ package org.team14.webty.security.authentication;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-import org.team14.webty.user.entity.WebtyUser;
-import org.team14.webty.user.repository.UserRepository;
 import org.team14.webty.user.service.UserService;
 
 import lombok.RequiredArgsConstructor;
@@ -13,18 +11,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebtyUserDetailsService implements UserDetailsService {
 
-	private final UserRepository userRepository;
 	private final UserService userService;
-
-	public WebtyUserDetails loadUserByUserId(Long userId) {
-		return loadUserByUsername(userService.findNickNameByUserId(userId));
-	}
 
 	@Override
 	public WebtyUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-		WebtyUser webtyUser = userRepository.findByNickname(username)
-			.orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+		return new WebtyUserDetails(userService.findByNickName(username));
+	}
 
-		return new WebtyUserDetails(webtyUser);
+	public WebtyUserDetails loadUserByUserId(Long userId) {
+		return loadUserByUsername(userService.findNickNameByUserId(userId));
 	}
 }

--- a/src/main/java/org/team14/webty/security/oauth2/LoginSuccessHandler.java
+++ b/src/main/java/org/team14/webty/security/oauth2/LoginSuccessHandler.java
@@ -62,13 +62,13 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 		log.debug("PROVIDER : {}", provider);
 		log.debug("PROVIDER_ID : {}", providerId);
 
-		if (existUserId.isPresent()) { // 신규 유저인 경우
+		if (existUserId.isPresent()) {
 			log.debug("기존 유저입니다.");
-			return existUserId.get();
+			return existUserId.get(); // 기존 유저인 경우
 		}
 
 		log.debug("신규 유저입니다. 등록을 진행합니다.");
-		return userService.createUser(SocialProviderType.fromProviderName(provider), providerId);
+		return userService.createUser(SocialProviderType.fromProviderName(provider), providerId); // 신규 유저인 경우
 	}
 
 }

--- a/src/main/java/org/team14/webty/security/token/JwtManager.java
+++ b/src/main/java/org/team14/webty/security/token/JwtManager.java
@@ -9,13 +9,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.security.authentication.WebtyUserDetailsService;
 import org.team14.webty.security.policy.ExpirationPolicy;
-import org.team14.webty.user.entity.WebtyUser;
-import org.team14.webty.user.service.UserService;
 
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -30,8 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtManager {
 	private final WebtyUserDetailsService webtyUserDetailsService;
 	private final RedisTemplate<String, String> redisTemplate;
-	private final UserService userService;
-	
+
 	@Value("${jwt.secret}")
 	private String secret;
 	private SecretKey secretKey;
@@ -126,20 +122,10 @@ public class JwtManager {
 		}
 	}
 
-	// public Authentication getAuthentication(String accessToken) {
-	// 	WebtyUserDetails webtyUserDetails = webtyUserDetailsService.loadUserByUserId(
-	// 		getUserIdByToken(accessToken));
-	// 	return new UsernamePasswordAuthenticationToken(webtyUserDetails, "",
-	// 		webtyUserDetails.getAuthorities());  // 인증 객체 생성
-	// }
-
 	public Authentication getAuthentication(String accessToken) {
 		WebtyUserDetails webtyUserDetails = webtyUserDetailsService.loadUserByUserId(
 			getUserIdByToken(accessToken));
-		WebtyUser webtyUser = userService.findByNickName(webtyUserDetails.getUsername()).orElseThrow(
-			() -> new UsernameNotFoundException("유저를 찾을 수 없습니다.")
-		);
-		return new UsernamePasswordAuthenticationToken(webtyUser, "",
+		return new UsernamePasswordAuthenticationToken(webtyUserDetails, "",
 			webtyUserDetails.getAuthorities());  // 인증 객체 생성
 	}
 }

--- a/src/main/java/org/team14/webty/user/controller/UserController.java
+++ b/src/main/java/org/team14/webty/user/controller/UserController.java
@@ -39,26 +39,26 @@ public class UserController { // 예외 처리 추가 필요
 		// 	return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
 		// 		.body(new NicknameResponse("로그인이 필요합니다."));
 		// } //dto 수정 작업과 함께 예외 처리 추가 필요
-		userService.modifyNickname(webtyUserDetails.getWebtyUser(), request.getNickname());
+		userService.modifyNickname(webtyUserDetails, request.getNickname());
 		return ResponseEntity.ok(new NicknameResponse("닉네임이 변경되었습니다."));
 	}
 
 	@GetMapping("/info")
 	public ResponseEntity<UserDataResponse> getUserData(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails) {
-		return ResponseEntity.ok(new UserDataResponse(webtyUserDetails.getWebtyUser()));
+		return ResponseEntity.ok(new UserDataResponse(userService.getAuthenticatedUser(webtyUserDetails)));
 	}
 
 	@PatchMapping("/profileImage")
 	public ResponseEntity<ImageResponse> changeProfileImg(
 		@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestParam("file") MultipartFile file) throws IOException {
-		userService.modifyImage(webtyUserDetails.getWebtyUser(), file);
+		userService.modifyImage(webtyUserDetails, file);
 		return ResponseEntity.ok(new ImageResponse("프로필사진이 변경되었습니다."));
 	}
 
 	@DeleteMapping("/users")
 	public ResponseEntity<Void> delete(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails) {
-		userService.delete(webtyUserDetails.getWebtyUser());
+		userService.delete(webtyUserDetails);
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/org/team14/webty/user/controller/UserController.java
+++ b/src/main/java/org/team14/webty/user/controller/UserController.java
@@ -12,11 +12,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.user.dto.ImageResponse;
 import org.team14.webty.user.dto.NicknameRequest;
 import org.team14.webty.user.dto.NicknameResponse;
 import org.team14.webty.user.dto.UserDataResponse;
-import org.team14.webty.user.entity.WebtyUser;
 import org.team14.webty.user.service.UserService;
 
 import jakarta.validation.Valid;
@@ -27,36 +27,38 @@ import lombok.extern.slf4j.Slf4j;
 @RequestMapping("/user")
 @RequiredArgsConstructor
 @Slf4j
-public class UserController {
+public class UserController { // 예외 처리 추가 필요
 
 	private final UserService userService;
 
 	@PatchMapping("/nickname")
 	public ResponseEntity<NicknameResponse> changeNickname(
-		@AuthenticationPrincipal WebtyUser webtyUser,
+		@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestBody @Valid NicknameRequest request) {
-		String nickname = request.getNickname();
-		userService.modifyNickname(webtyUser, nickname);
+		// if (webtyUserDetails == null) {
+		// 	return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+		// 		.body(new NicknameResponse("로그인이 필요합니다."));
+		// } //dto 수정 작업과 함께 예외 처리 추가 필요
+		userService.modifyNickname(webtyUserDetails.getWebtyUser(), request.getNickname());
 		return ResponseEntity.ok(new NicknameResponse("닉네임이 변경되었습니다."));
 	}
 
-	// UserInfoResponse가 스프링에 이미 있어서 응답객체의 이름을 UserDataResponse를 사용했습니다.
 	@GetMapping("/info")
-	public ResponseEntity<UserDataResponse> getUserData(@AuthenticationPrincipal WebtyUser webtyUser) {
-		return ResponseEntity.ok(new UserDataResponse(webtyUser));
+	public ResponseEntity<UserDataResponse> getUserData(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails) {
+		return ResponseEntity.ok(new UserDataResponse(webtyUserDetails.getWebtyUser()));
 	}
 
 	@PatchMapping("/profileImage")
 	public ResponseEntity<ImageResponse> changeProfileImg(
-		@AuthenticationPrincipal WebtyUser webtyUser,
+		@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestParam("file") MultipartFile file) throws IOException {
-		userService.modifyImage(webtyUser, file);
+		userService.modifyImage(webtyUserDetails.getWebtyUser(), file);
 		return ResponseEntity.ok(new ImageResponse("프로필사진이 변경되었습니다."));
 	}
 
 	@DeleteMapping("/users")
-	public ResponseEntity<Void> delete(@AuthenticationPrincipal WebtyUser webtyuser) {
-		userService.delete(webtyuser);
+	public ResponseEntity<Void> delete(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails) {
+		userService.delete(webtyUserDetails.getWebtyUser());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/org/team14/webty/user/dto/UserDataResponse.java
+++ b/src/main/java/org/team14/webty/user/dto/UserDataResponse.java
@@ -5,7 +5,7 @@ import org.team14.webty.user.entity.WebtyUser;
 import lombok.Getter;
 
 @Getter
-public class UserDataResponse {
+public class UserDataResponse { // UserInfoResponse가 스프링에 이미 있어서 UserDataResponse 사용
 	private final String nickname;
 	private final String profileImage;
 

--- a/src/main/java/org/team14/webty/user/entity/WebtyUser.java
+++ b/src/main/java/org/team14/webty/user/entity/WebtyUser.java
@@ -14,12 +14,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
-
-import java.util.Collection;
-import java.util.List;
 
 @Entity
 @Getter
@@ -27,7 +21,7 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 @Table(name = "webty_user")
-public class WebtyUser implements UserDetails {
+public class WebtyUser {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "id")
@@ -52,21 +46,4 @@ public class WebtyUser implements UserDetails {
 		this.nickname = nickname;
 		this.profileImage = profileImage;
 	}
-
-	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return List.of(new SimpleGrantedAuthority("ROLE_USER"));
-	}
-
-	@Override
-	public String getPassword() {
-		return "";  // 필요한 경우 비밀번호 필드 추가
-	}
-
-	@Override
-	public String getUsername() {
-		return nickname;
-	}
-
-	// ... UserDetails의 나머지 메서드 구현
 }

--- a/src/main/java/org/team14/webty/user/repository/UserRepository.java
+++ b/src/main/java/org/team14/webty/user/repository/UserRepository.java
@@ -12,5 +12,6 @@ public interface UserRepository extends JpaRepository<WebtyUser, Long> {
 	Optional<WebtyUser> findByNickname(String nickname);
 
 	Optional<WebtyUser> findBySocialProvider(SocialProvider socialProvider);
+
 	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/team14/webty/user/service/UserService.java
+++ b/src/main/java/org/team14/webty/user/service/UserService.java
@@ -27,24 +27,6 @@ public class UserService {
 	private final SocialProviderRepository socialProviderRepository;
 	private final FileStorageUtil fileStorageUtil;
 
-	// @Transactional(readOnly = true)
-	// public WebtyUser findUserByNickname(String nickname) {
-	// 	Optional<WebtyUser> opWebtyUser = userRepository.findByNickname(nickname);
-	// 	if (opWebtyUser.isEmpty()) {
-	// 		throw new IllegalArgumentException("존재하지 않는 닉네임");
-	// 	}
-	// 	return opWebtyUser.get();
-	// }
-
-	// @Transactional(readOnly = true)
-	// public WebtyUser findUserById(Long userId) {
-	// 	Optional<WebtyUser> opWebtyUser = userRepository.findById(userId);
-	// 	if (opWebtyUser.isEmpty()) {
-	// 		throw new IllegalArgumentException("존재하지 않는 userId");
-	// 	}
-	// 	return opWebtyUser.get();
-	// }
-
 	@Transactional(readOnly = true)
 	public Optional<Long> existSocialProvider(String providerId) {
 		return socialProviderRepository.findByProviderId(providerId)

--- a/src/main/java/org/team14/webty/user/service/UserService.java
+++ b/src/main/java/org/team14/webty/user/service/UserService.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.team14.webty.common.util.FileStorageUtil;
+import org.team14.webty.security.authentication.AuthWebtyUserProvider;
+import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.user.entity.SocialProvider;
 import org.team14.webty.user.entity.WebtyUser;
 import org.team14.webty.user.enumerate.SocialProviderType;
@@ -25,6 +27,7 @@ public class UserService {
 
 	private final UserRepository userRepository;
 	private final SocialProviderRepository socialProviderRepository;
+	private final AuthWebtyUserProvider authWebtyUserProvider;
 	private final FileStorageUtil fileStorageUtil;
 
 	@Transactional(readOnly = true)
@@ -68,7 +71,9 @@ public class UserService {
 	}
 
 	@Transactional
-	public void modifyNickname(WebtyUser webtyUser, String nickname) {
+	public void modifyNickname(WebtyUserDetails webtyUserDetails, String nickname) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+
 		if (userRepository.existsByNickname(nickname)) {
 			throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
 		}
@@ -77,20 +82,23 @@ public class UserService {
 	}
 
 	@Transactional
-	public void modifyImage(WebtyUser webtyUser, MultipartFile file) throws IOException {
+	public void modifyImage(WebtyUserDetails webtyUserDetails, MultipartFile file) throws IOException {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+
 		String filePath = fileStorageUtil.storeImageFile(file, "User_" + webtyUser.getUserId());
+
 		webtyUser.updateProfile(webtyUser.getNickname(), filePath);
 		userRepository.save(webtyUser);
 	}
 
 	@Transactional
-	public void delete(WebtyUser webtyUser) {
+	public void delete(WebtyUserDetails webtyUserDetails) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
 
-		Optional<WebtyUser> opWebtyUser = userRepository.findById(webtyUser.getUserId());
-		if (opWebtyUser.isEmpty()) {
-			throw new IllegalArgumentException("존재하지 않는 유저");
-		}
-		userRepository.delete(webtyUser);
+		WebtyUser existingUser = userRepository.findById(webtyUser.getUserId())
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저"));
+
+		userRepository.delete(existingUser);
 	}
 
 	@Transactional
@@ -100,7 +108,12 @@ public class UserService {
 		return webtyUser.getNickname();
 	}
 
-	public Optional<WebtyUser> findByNickName(String nickName) {
-		return userRepository.findByNickname(nickName);
+	public WebtyUser findByNickName(String nickName) {
+		return userRepository.findByNickname(nickName)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 userId"));
+	}
+
+	public WebtyUser getAuthenticatedUser(WebtyUserDetails webtyUserDetails) {
+		return authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
 	}
 }

--- a/src/main/java/org/team14/webty/webtoon/controller/FavoriteController.java
+++ b/src/main/java/org/team14/webty/webtoon/controller/FavoriteController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.team14.webty.user.entity.WebtyUser;
+import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.webtoon.dto.FavoriteDto;
 import org.team14.webty.webtoon.dto.WebtoonResponseDto;
 import org.team14.webty.webtoon.service.FavoriteService;
@@ -27,25 +27,23 @@ public class FavoriteController {
 	private final FavoriteService favoriteService;
 
 	@PostMapping("/add")
-	public ResponseEntity<Void> add(@AuthenticationPrincipal WebtyUser webtyUser,
+	public ResponseEntity<Void> add(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestBody FavoriteDto favoriteDto) {
-		Long userId = webtyUser.getUserId();
-		favoriteService.addFavorite(userId, favoriteDto);
+		favoriteService.addFavorite(webtyUserDetails, favoriteDto);
 		return ResponseEntity.noContent().build();
 	}
 
 	@DeleteMapping("/delete")
-	public ResponseEntity<Void> delete(@AuthenticationPrincipal WebtyUser webtyUser,
+	public ResponseEntity<Void> delete(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestBody FavoriteDto favoriteDto) {
-		Long userId = webtyUser.getUserId();
-		favoriteService.deleteFavorite(userId, favoriteDto);
+		favoriteService.deleteFavorite(webtyUserDetails, favoriteDto);
 		return ResponseEntity.noContent().build();
 	}
 
 	@GetMapping("/list")
-	public ResponseEntity<List<WebtoonResponseDto>> getUserFavorite(@AuthenticationPrincipal WebtyUser webtyUser) {
-		Long userId = webtyUser.getUserId();
-		List<WebtoonResponseDto> userFavorites = favoriteService.getUserFavorites(userId);
+	public ResponseEntity<List<WebtoonResponseDto>> getUserFavorite(
+		@AuthenticationPrincipal WebtyUserDetails webtyUserDetails) {
+		List<WebtoonResponseDto> userFavorites = favoriteService.getUserFavorites(webtyUserDetails);
 		return ResponseEntity.ok().body(userFavorites);
 	}
 }

--- a/src/main/java/org/team14/webty/webtoon/service/FavoriteService.java
+++ b/src/main/java/org/team14/webty/webtoon/service/FavoriteService.java
@@ -3,11 +3,11 @@ package org.team14.webty.webtoon.service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.team14.webty.security.authentication.AuthWebtyUserProvider;
+import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.user.entity.WebtyUser;
-import org.team14.webty.user.repository.UserRepository;
 import org.team14.webty.webtoon.dto.FavoriteDto;
 import org.team14.webty.webtoon.dto.WebtoonResponseDto;
 import org.team14.webty.webtoon.entity.Favorite;
@@ -24,42 +24,38 @@ import lombok.RequiredArgsConstructor;
 public class FavoriteService {
 
 	private final FavoriteRepository favoriteRepository;
-	private final UserRepository userRepository;
 	private final WebtoonRepository webtoonRepository;
+	private final AuthWebtyUserProvider authWebtyUserProvider;
 
 	@Transactional
-	public void addFavorite(Long userId, FavoriteDto favoriteDto) {
-		WebtyUser user = userRepository.findById(userId)
-			.orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다."));
+	public void addFavorite(WebtyUserDetails webtyUserDetails, FavoriteDto favoriteDto) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
 
 		Webtoon webtoon = webtoonRepository.findById(favoriteDto.getWebtoonId())
 			.orElseThrow(() -> new IllegalArgumentException("웹툰이 존재하지 않습니다."));
 
-		if (favoriteRepository.findByWebtyUserAndWebtoon(user, webtoon).isPresent()) {
+		if (favoriteRepository.findByWebtyUserAndWebtoon(webtyUser, webtoon).isPresent()) {
 			throw new IllegalArgumentException("이미 관심 웹툰으로 등록되었습니다.");
 		}
 
-		Favorite favorite = FavoriteMapper.toEntity(user, webtoon);
-		favoriteRepository.save(favorite);
+		favoriteRepository.save(FavoriteMapper.toEntity(webtyUser, webtoon));
 	}
 
 	@Transactional
-	public void deleteFavorite(Long userId, FavoriteDto favoriteDto) {
-		WebtyUser user = userRepository.findById(userId)
-			.orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다."));
+	public void deleteFavorite(WebtyUserDetails webtyUserDetails, FavoriteDto favoriteDto) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
 
 		Webtoon webtoon = webtoonRepository.findById(favoriteDto.getWebtoonId())
 			.orElseThrow(() -> new IllegalArgumentException("웹툰이 존재하지 않습니다."));
 
-		favoriteRepository.deleteByWebtyUserAndWebtoon(user, webtoon);
+		favoriteRepository.deleteByWebtyUserAndWebtoon(webtyUser, webtoon);
 	}
 
 	@Transactional(readOnly = true)
-	public List<WebtoonResponseDto> getUserFavorites(Long userId) {
-		WebtyUser user = userRepository.findById(userId)
-			.orElseThrow(() -> new UsernameNotFoundException("유저가 존재하지 않습니다."));
+	public List<WebtoonResponseDto> getUserFavorites(WebtyUserDetails webtyUserDetails) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
 
-		return favoriteRepository.findByWebtyUser(user)
+		return favoriteRepository.findByWebtyUser(webtyUser)
 			.stream()
 			.map(Favorite::getWebtoon)
 			.map(WebtoonApiResponseMapper::toDto)


### PR DESCRIPTION
### 요약
- `WebtyUser` 책임 분리:
    인증에서는 `webtyUserDetails`, 일반 서비스에서는 `WebtyUser`를 사용하도록 수정함
- `AuthWebtyUserProvider` 구현:
    `webtyUserDetails`로부터 `WebtyUser`를 안전하게 가져오는 클래스

### 상세
- JwtManager 수정:
    - getAuthentication 수정: webtyUserDetails 사용
- AuthWebtyUserProvider 구현:
    - `webtyUserDetails`로부터 `WebtyUser`를 안전하게 가져와서 리턴
    - 예외처리 개선 필요
- WebtyUser 수정: UserDetails 구현체 -> 도메인 User

- UserController 수정:
    - 모든 요청 처리 webtyUserDetails 사용
- UserService 수정: 
    - `AuthWebtyUserProvider` 사용
    - 사용하지 않는 주석 제거
- FavoriteController 수정:
    - `webtyUserDetails` 사용
- FavoriteService 수정: 
    - `AuthWebtyUserProvider` 사용

- WebtyUserDetailsService 수정:
    - `userRepository`를 직접 호출하지 않고 `userService` 호출로 처리
    
- UserRepository 수정: 단순 줄바꿈 수정
- UserDataResponse 수정: 주석 추가
- LoginSuccessHandler 수정: 잘못된 주석 수정


### 테스트
- 1차 수정) 기능 테스트 진행 목록:
  - [x] login
  - [x] logout
  - [x] user/info
  - [ ] delete
- 2차 수정) 실행 되는지만 확인함

### 참고
[velog에 작성한 Principal 관련 글](https://velog.io/@dia218/Principal)

---

close #68