### PR TITLE
improvement: 멘토링 결과 반영

### DIFF
--- a/src/main/java/org/team14/webty/reviewComment/dto/CommentResponse.java
+++ b/src/main/java/org/team14/webty/reviewComment/dto/CommentResponse.java
@@ -10,8 +10,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/org/team14/webty/reviewComment/entity/ReviewComment.java
+++ b/src/main/java/org/team14/webty/reviewComment/entity/ReviewComment.java
@@ -16,7 +16,10 @@ import java.util.Set;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "review_comment")
+@Table(name = "review_comment", indexes = {
+    @Index(name = "idx_review_comment", columnList = "review_id, depth, comment_id DESC"),
+    @Index(name = "idx_parent_comment", columnList = "parent_id, comment_id ASC")
+})
 public class ReviewComment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/org/team14/webty/reviewComment/repository/ReviewCommentRepository.java
+++ b/src/main/java/org/team14/webty/reviewComment/repository/ReviewCommentRepository.java
@@ -14,18 +14,18 @@ import org.team14.webty.reviewComment.entity.ReviewComment;
 public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Long> {
 	// 특정 리뷰의 모든 댓글을 depth와 생성일시 순으로 조회
 	@Query("SELECT rc FROM ReviewComment rc WHERE rc.review.reviewId = :reviewId " +
-		"ORDER BY rc.depth ASC, rc.createdAt DESC")
-	Page<ReviewComment> findAllByReviewIdOrderByDepthAndCreatedAt(
+		"ORDER BY rc.depth ASC, rc.commentId DESC")
+	Page<ReviewComment> findAllByReviewIdOrderByDepthAndCommentId(
 		@Param("reviewId") Long reviewId,
 		Pageable pageable
 	);
 
 	// 특정 댓글의 대댓글 목록 조회
-	List<ReviewComment> findByParentIdOrderByCreatedAtAsc(Long parentId);
+	List<ReviewComment> findByParentIdOrderByCommentIdAsc(Long parentId);
 
 	// 루트 댓글만 조회 (depth = 0)
 	@Query("SELECT rc FROM ReviewComment rc WHERE rc.review.reviewId = :reviewId AND rc.depth = 0 " +
-		"ORDER BY rc.createdAt ASC")
+		"ORDER BY rc.commentId DESC")
 	List<ReviewComment> findRootComments(@Param("reviewId") Long reviewId);
 
 	// 특정 댓글의 모든 하위 댓글 조회 (재귀적으로)
@@ -47,8 +47,8 @@ public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Lo
 	List<ReviewComment> findByReviewIdAndDepth(@Param("reviewId") Long reviewId, @Param("depth") Integer depth);
 
 	@Query("SELECT rc FROM ReviewComment rc WHERE rc.review.reviewId = :reviewId " +
-		"ORDER BY CASE WHEN rc.depth = 0 THEN rc.createdAt " +
-		"ELSE (SELECT p.createdAt FROM ReviewComment p WHERE p.commentId = rc.parentId) END DESC, " +
-		"rc.depth ASC, rc.createdAt ASC")
-	List<ReviewComment> findAllByReviewIdOrderByParentCreatedAtAndDepth(@Param("reviewId") Long reviewId);
+		"ORDER BY CASE WHEN rc.depth = 0 THEN rc.commentId " +
+		"ELSE (SELECT p.commentId FROM ReviewComment p WHERE p.commentId = rc.parentId) END DESC, " +
+		"rc.depth ASC, rc.commentId DESC")
+	List<ReviewComment> findAllByReviewIdOrderByParentCommentIdAndDepth(@Param("reviewId") Long reviewId);
 }

--- a/src/main/java/org/team14/webty/reviewComment/service/ReviewCommentService.java
+++ b/src/main/java/org/team14/webty/reviewComment/service/ReviewCommentService.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -36,7 +37,7 @@ public class ReviewCommentService {
 	private final ReviewCommentMapper commentMapper;
 
 	@Transactional
-	@CacheEvict(value = "comments", key = "#reviewId")
+	@Cacheable(value = "comments", key = "#reviewId")
 	public CommentResponse createComment(WebtyUser user, Long reviewId, CommentRequest request) {
 		Review review = reviewRepository.findById(reviewId)
 			.orElseThrow(() -> new IllegalArgumentException("리뷰를 찾을 수 없습니다."));
@@ -75,7 +76,7 @@ public class ReviewCommentService {
 	}
 
 	@Transactional
-	@CacheEvict(value = "comments", key = "#comment.review.reviewId")
+	@CachePut(value = "comments", key = "#comment.review.reviewId")
 	public CommentResponse updateComment(Long commentId, WebtyUser user, CommentRequest request) {
 		ReviewComment comment = commentRepository.findById(commentId)
 			.orElseThrow(CommentException::notFound);
@@ -99,7 +100,7 @@ public class ReviewCommentService {
 		}
 
 		// 대댓글이 있는 경우의 처리 정책 명확화 필요
-		List<ReviewComment> childComments = commentRepository.findByParentIdOrderByCreatedAtAsc(commentId);
+		List<ReviewComment> childComments = commentRepository.findByParentIdOrderByCommentIdAsc(commentId);
 		if (!childComments.isEmpty()) {
 			// 정책 1: 대댓글도 모두 삭제
 			commentRepository.deleteAll(childComments);
@@ -117,39 +118,36 @@ public class ReviewCommentService {
 	public List<CommentResponse> getCommentsByReviewId(Long reviewId) {
 		Pageable pageable = PageRequest.of(0, Integer.MAX_VALUE);
 		Page<ReviewComment> commentPage = commentRepository
-			.findAllByReviewIdOrderByDepthAndCreatedAt(reviewId, pageable);
-		List<ReviewComment> allComments = commentPage.getContent();  // Page를 List로 변환
+			.findAllByReviewIdOrderByDepthAndCommentId(reviewId, pageable);
+		List<ReviewComment> allComments = commentPage.getContent();
 
-		// 댓글들을 Map으로 구성 (parentId를 키로 사용)
+		// 부모 댓글 ID를 키로 사용하는 Map 초기화
 		Map<Long, List<CommentResponse>> commentMap = new HashMap<>();
-		List<CommentResponse> rootComments = new ArrayList<>();
 
-		// 댓글 트리 구조 구성
-		for (ReviewComment comment : allComments) {
-			CommentResponse response = commentMapper.toResponse(comment);
-			if (comment.getParentId() == null) {
-				rootComments.add(response);
-			} else {
-				commentMap
-					.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
-					.add(response);
-			}
-		}
+		// 모든 댓글을 CommentResponse로 변환하고 부모-자식 관계로 구성
+		List<CommentResponse> rootComments = allComments.stream()
+			.map(commentMapper::toResponse)
+			.filter(comment -> {
+				if (comment.getParentId() != null) {
+					commentMap
+						.computeIfAbsent(comment.getParentId(), k -> new ArrayList<>())
+						.add(comment);
+					return false;
+				}
+				return true;
+			})
+			.collect(Collectors.toList());
 
-		// 각 댓글의 대댓글 설정
-		for (CommentResponse response : rootComments) {
-			setChildComments(response, commentMap);
-		}
+		// 각 루트 댓글에 대해 자식 댓글들을 설정
+		rootComments.forEach(root -> setChildComments(root, commentMap));
 
 		return rootComments;
 	}
 
 	private void setChildComments(CommentResponse parent, Map<Long, List<CommentResponse>> commentMap) {
 		List<CommentResponse> children = commentMap.getOrDefault(parent.getCommentId(), new ArrayList<>());
-		//parent.setChildComments(children); //에러나서 임시 주석처리
-		for (CommentResponse child : children) {
-			setChildComments(child, commentMap);
-		}
+		parent.setChildComments(children);
+		children.forEach(child -> setChildComments(child, commentMap));
 	}
 
 	// CommentException을 내부 static 클래스로 이동

--- a/src/test/java/org/team14/webty/reviewComment/ReviewCommentControllerTest.java
+++ b/src/test/java/org/team14/webty/reviewComment/ReviewCommentControllerTest.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import java.util.Collections;
 
 @WebMvcTest(ReviewCommentController.class)
 @Import({ReviewCommentControllerTest.TestSecurityConfig.class, ReviewCommentControllerTest.TestWebConfig.class})
@@ -53,7 +54,7 @@ class ReviewCommentControllerTest {
 	void setUp() {
 		testUser = createTestUser();
 		SecurityContextHolder.getContext()
-			.setAuthentication(new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities()));
+			.setAuthentication(new UsernamePasswordAuthenticationToken(testUser, null, Collections.emptyList()));
 	}
 
 	private WebtyUser createTestUser() {


### PR DESCRIPTION
Close #85 

# 멘토님 권장사항 반영

## 1. @CacheEvict 관련 수정
- 댓글 생성시 : @Cacheable
- 댓글 수정시 : @CachePut
** 구글링이나 챗GPT 물어보니 댓글 생성 시에도 `@CacheEvict`를 사용하여 캐시를 무효화하고, 조회 시에 새로운 전체 목록을 캐시하는 것이 데이터 일관성을 유지하는 올바른 방법이라고 하네요. 하지만 우선 멘토님께서 도움주신대로 하겠습니다.**

## 2.```ReviewCommentRepository```파일의 ```createdId``` -> ```commentId```로 수정
-**인덱스 관점에서의 차이점**
1) **성능적 측면**:
   - `commentId`는 보통 Primary Key로 자동 증가하는 값이므로 이미 클러스터드 인덱스가 생성되어 있습니다.
   - `createdAt`은 별도의 인덱스를 생성해야 하므로 추가적인 저장 공간이 필요합니다.

2) **동시성 처리**:
   - `createdAt`의 경우 밀리초 단위로 동일한 시간이 들어갈 수 있어 정확한 순서 보장이 어려울 수 있습니다.
   - `commentId`는 자동 증가 값이므로 항상 유니크하고 순차적인 순서가 보장됩니다.

3) **인덱스 효율성**:
   ```sql
   CREATE INDEX idx_review_comment ON review_comment (review_id, depth, comment_id DESC);
   ```
   - 이런 복합 인덱스를 사용할 때 `commentId`가 더 효율적입니다.
   - `commentId`는 카디널리티(고유값의 수)가 높아 인덱스 선택성이 좋습니다.
   - `createdAt`은 같은 시간대의 데이터가 있을 수 있어 선택성이 상대적으로 낮을 수 있습니다.

4) **저장 공간**:
   - `commentId`는 일반적으로 8바이트(BIGINT)
   - `createdAt`은 일반적으로 8바이트(TIMESTAMP)
   - 하지만 `commentId`는 이미 PK로 존재하는 값을 재사용하므로 추가 공간이 필요 없습니다.

## 3. 불변성 문제로 stream API 구현
- 원래코드의 문제점
1. `rootComments`가 두 번 선언되어 있습니다 (`List.of()`와 stream으로).
2. `commentMap`이 비어있는 상태로 선언되어 있습니다 (`Map.of()`).

- 변경했을 때의 장점들:

1. **코드가독성 및 성능 개선**: 
   - 한 번의 순회로 모든 댓글을 분류하고 구조화
   - 불필요한 중복 작업 및 변수 중복 선언을 제거

2. **유지보수성**:
   - 각 단계가 명확하게 구분되어 있어 수정이 용이합니다.
   - 에러 발생 가능성이 줄어들었습니다.

# 바뀐 코드에 맞춰 테스트케이스 코드도 조금 손봤습니다.