### PR TITLE
feat: 추천수 관련 기능 추가

### DIFF
--- a/src/main/java/org/team14/webty/recommend/repository/RecommendRepository.java
+++ b/src/main/java/org/team14/webty/recommend/repository/RecommendRepository.java
@@ -1,5 +1,6 @@
 package org.team14.webty.recommend.repository;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -40,4 +41,10 @@ public interface RecommendRepository extends JpaRepository<Recommend, Long> {
     ORDER BY (SELECT MAX(rec.voteId) FROM Recommend rec WHERE rec.review.reviewId = r.reviewId) DESC
 """)
 	Page<Review> getUserRecommendReview(@Param("userId") Long userId, Pageable pageable);
+
+	@Query("SELECT COALESCE(COUNT(r.voteId), 0) " +
+		"FROM Review rv LEFT JOIN Recommend r ON rv.reviewId = r.review.reviewId AND r.likeType = 'LIKE' " +
+		"WHERE rv.reviewId IN :reviewIds " +
+		"GROUP BY rv.reviewId ORDER BY rv.reviewId")
+	List<Long> getLikeCounts(@Param("reviewIds") List<Long> reviewIds);
 }

--- a/src/main/java/org/team14/webty/review/dto/ReviewDetailResponse.java
+++ b/src/main/java/org/team14/webty/review/dto/ReviewDetailResponse.java
@@ -1,6 +1,8 @@
 package org.team14.webty.review.dto;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.team14.webty.common.dto.PageDto;
 import org.team14.webty.review.enumrate.SpoilerStatus;
@@ -22,4 +24,7 @@ public class ReviewDetailResponse {
 	private String thumbnailUrl;
 	private List<String> imageUrls;
 	private PageDto<CommentResponse> commentResponses;
+	private LocalDateTime createdAt;
+	private LocalDateTime updatedAt;
+	private Map<String,Long> recommendCount;
 }

--- a/src/main/java/org/team14/webty/review/dto/ReviewItemResponse.java
+++ b/src/main/java/org/team14/webty/review/dto/ReviewItemResponse.java
@@ -26,4 +26,5 @@ public class ReviewItemResponse {
 	private String thumbnailUrl;
 	private List<String> imageUrls;
 	private Integer commentCount;
+	private Long recommendCount;
 }

--- a/src/main/java/org/team14/webty/review/mapper/ReviewMapper.java
+++ b/src/main/java/org/team14/webty/review/mapper/ReviewMapper.java
@@ -2,6 +2,7 @@ package org.team14.webty.review.mapper;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 import org.team14.webty.common.dto.PageDto;
 import org.team14.webty.review.dto.ReviewDetailResponse;
@@ -28,7 +29,7 @@ public class ReviewMapper {
 	}
 
 	public static ReviewItemResponse toResponse(Review review, List<CommentResponse> comments,
-		List<String> imageUrls) {
+		List<String> imageUrls, Long likeCount) {
 		return ReviewItemResponse.builder()
 			.reviewId(review.getReviewId())
 			.userDataResponse(new UserDataResponse(review.getUser()))
@@ -41,11 +42,12 @@ public class ReviewMapper {
 			.thumbnailUrl(review.getWebtoon().getThumbnailUrl())
 			.imageUrls(imageUrls)
 			.commentCount(comments.size()) // 댓글 개수만
+			.recommendCount(likeCount)
 			.build();
 	}
 
 	public static ReviewDetailResponse toDetail(Review review, PageDto<CommentResponse> comments,
-		List<ReviewImage> reviewImages) {
+		List<ReviewImage> reviewImages, Map<String, Long> recommendCount) {
 		return ReviewDetailResponse.builder()
 			.reviewId(review.getReviewId())
 			.userDataResponse(new UserDataResponse(review.getUser()))
@@ -56,6 +58,9 @@ public class ReviewMapper {
 			.thumbnailUrl(review.getWebtoon().getThumbnailUrl())
 			.imageUrls(reviewImages.stream().map(ReviewImage::getImageUrl).toList())
 			.commentResponses(comments) // 댓글 정보까지
+			.createdAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
+			.recommendCount(recommendCount)
 			.build();
 	}
 


### PR DESCRIPTION
글 전체조회 / 개별조회 시 DTO를 변경했고 그에 따라 Mapper수정 및 함수 추가했습니다.

전체조회시 like(좋아요?) 수만 리턴하고

    "recommendCount": 0



개별조회시 기존 것에 포함해 createdAt, updatedAt, recommendCount{ like, hate } 같이 리턴합니다.

    "createdAt": "2025-02-06T20:13:56.674716",
    "updatedAt": null,
    "recommendCount": {
        "hates": 0,
        "likes": 1
    }