### PR TITLE
[Vote] Feat: 유사 웹툰, 투표 기능

### DIFF
--- a/src/main/java/org/team14/webty/common/exception/ErrorCode.java
+++ b/src/main/java/org/team14/webty/common/exception/ErrorCode.java
@@ -25,7 +25,12 @@ public enum ErrorCode {
 	FILE_UPLOAD_TYPE_ERROR(HttpStatus.BAD_REQUEST, "FILE-001", "이미지파일 이외의 업로드는 불가능합니다."),
 	FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-002", "파일 업로드 중 오류가 발생했습니다."),
 	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-003", "파일 삭제 중 오류가 발생했습니다."),
-	DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-004", "디렉토리 생성 중 오류가 발생했습니다.");
+	DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-004", "디렉토리 생성 중 오류가 발생했습니다."),
+	SIMILAR_NOT_FOUND(HttpStatus.NOT_FOUND, "SIMILAR-001", "유사웹툰이 등록 되어 있지 않습니다."),
+	SIMILAR_DUPLICATION_ERROR(HttpStatus.BAD_REQUEST, "SIMILAR-002", "이미 등록된 유사웹툰입니다."),
+	INVALID_SIMILAR_NAME(HttpStatus.BAD_REQUEST, "SIMILAR-003", "유사웹툰 이름이 유효하지 않습니다."),
+	VOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "VOTE-001", "투표 내역을 찾을 수 없습니다."),
+	VOTE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "VOTE-002", "이미 투표한 내역이 존재합니다.");
 
 	private final HttpStatus httpStatus;
 	private final String errorCode;

--- a/src/main/java/org/team14/webty/security/config/SecurityConfig.java
+++ b/src/main/java/org/team14/webty/security/config/SecurityConfig.java
@@ -73,7 +73,8 @@ public class SecurityConfig {
 		return web -> web.ignoring().requestMatchers(
 			"/v3/**", "/swagger-ui/**", "/api/logistics",
 			"h2-console/**", "/error", "/webtoons/**" // 테스트 이후 제거할 목록
-			, "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc", "/reviews/search"
+			, "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc", "/reviews/search",
+			"/similar", "/similar/{id:\\d+}"
 		).requestMatchers(PathRequest.toH2Console());
 	}
 

--- a/src/main/java/org/team14/webty/voting/controller/SimilarController.java
+++ b/src/main/java/org/team14/webty/voting/controller/SimilarController.java
@@ -1,0 +1,58 @@
+package org.team14.webty.voting.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.team14.webty.common.dto.PageDto;
+import org.team14.webty.common.mapper.PageMapper;
+import org.team14.webty.security.authentication.WebtyUserDetails;
+import org.team14.webty.voting.dto.SimilarRequest;
+import org.team14.webty.voting.dto.SimilarResponse;
+import org.team14.webty.voting.dto.SimilarResponseRequest;
+import org.team14.webty.voting.service.SimilarService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/similar")
+public class SimilarController {
+	private final SimilarService similarService;
+
+	// 유사 웹툰 등록
+	@PostMapping("/create")
+	public ResponseEntity<Long> createSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
+		@RequestBody SimilarRequest similarRequest) {
+		return ResponseEntity.ok().body(similarService.createSimilar(webtyUserDetails, similarRequest.getWebtoonId(),
+			similarRequest.getSimilarWebtoonName()));
+	}
+
+	// 유사 웹툰 삭제
+	@DeleteMapping("/delete/{similarId}")
+	public ResponseEntity<Void> deleteSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
+		@PathVariable(value = "similarId") Long similarId) {
+		similarService.deleteSimilar(webtyUserDetails, similarId);
+		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping
+	public ResponseEntity<PageDto<SimilarResponse>> getSimilarList(
+		@RequestParam(value = "page", defaultValue = "0") int page,
+		@RequestParam(value = "size", defaultValue = "10") int size,
+		@RequestBody SimilarResponseRequest similarResponseRequest) {
+		return ResponseEntity.ok()
+			.body(PageMapper.toPageDto(similarService.findAll(similarResponseRequest.getWebtoonId(), page, size)));
+	}
+
+	@GetMapping("/{similarId}")
+	public ResponseEntity<SimilarResponse> getSimilar(@PathVariable(value = "similarId") Long similarId) {
+		return ResponseEntity.ok().body(similarService.getSimilar(similarId));
+	}
+}

--- a/src/main/java/org/team14/webty/voting/controller/VoteController.java
+++ b/src/main/java/org/team14/webty/voting/controller/VoteController.java
@@ -1,4 +1,37 @@
 package org.team14.webty.voting.controller;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.team14.webty.security.authentication.WebtyUserDetails;
+import org.team14.webty.voting.dto.VoteRequest;
+import org.team14.webty.voting.service.VoteService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/vote")
 public class VoteController {
+	private final VoteService voteService;
+
+	// 투표
+	@PostMapping
+	public ResponseEntity<Long> vote(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
+		@RequestBody VoteRequest voteRequest) {
+		return ResponseEntity.ok().body(voteService.vote(webtyUserDetails, voteRequest));
+	}
+
+	// 투표 취소
+	@DeleteMapping("{voteId}")
+	public ResponseEntity<Void> cancel(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
+		@PathVariable(value = "voteId") Long voteId) {
+		voteService.cancel(webtyUserDetails, voteId);
+		return ResponseEntity.ok().build();
+	}
 }

--- a/src/main/java/org/team14/webty/voting/dto/SimilarRequest.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarRequest.java
@@ -1,0 +1,9 @@
+package org.team14.webty.voting.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SimilarRequest {
+	private Long webtoonId;
+	private String similarWebtoonName;
+}

--- a/src/main/java/org/team14/webty/voting/dto/SimilarResponse.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarResponse.java
@@ -1,0 +1,12 @@
+package org.team14.webty.voting.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimilarResponse {
+	private Long similarId;
+	private String thumbnailUrl;
+	private Long similarResult;
+}

--- a/src/main/java/org/team14/webty/voting/dto/SimilarResponseRequest.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarResponseRequest.java
@@ -1,0 +1,8 @@
+package org.team14.webty.voting.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SimilarResponseRequest {
+	private Long webtoonId;
+}

--- a/src/main/java/org/team14/webty/voting/dto/VoteRequest.java
+++ b/src/main/java/org/team14/webty/voting/dto/VoteRequest.java
@@ -1,0 +1,9 @@
+package org.team14.webty.voting.dto;
+
+import lombok.Getter;
+
+@Getter
+public class VoteRequest {
+	private Long similarId;
+	private String voteType;
+}

--- a/src/main/java/org/team14/webty/voting/entity/Similar.java
+++ b/src/main/java/org/team14/webty/voting/entity/Similar.java
@@ -1,4 +1,42 @@
 package org.team14.webty.voting.entity;
 
+import org.team14.webty.webtoon.entity.Webtoon;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+	name = "similar",
+	uniqueConstraints = @UniqueConstraint(columnNames = {"webtoonId", "similarWebtoonName"})
+)
 public class Similar {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long similarId;
+	private String similarWebtoonName;
+	private Long similarResult;
+	private Long userId;
+	@ManyToOne
+	@JoinColumn(name = "webtoonId")
+	private Webtoon webtoon;
+
+	public void updateSimilarResult(Long similarResult) {
+		this.similarResult = similarResult;
+	}
 }

--- a/src/main/java/org/team14/webty/voting/entity/Vote.java
+++ b/src/main/java/org/team14/webty/voting/entity/Vote.java
@@ -1,4 +1,34 @@
 package org.team14.webty.voting.entity;
 
+import org.team14.webty.voting.enumerate.VoteType;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Vote {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long voteId;
+	private Long userId;
+	@ManyToOne
+	@JoinColumn(name = "similarId")
+	private Similar similar;
+	@Enumerated(value = EnumType.STRING)
+	private VoteType voteType;
 }

--- a/src/main/java/org/team14/webty/voting/enumerate/VoteType.java
+++ b/src/main/java/org/team14/webty/voting/enumerate/VoteType.java
@@ -1,0 +1,24 @@
+package org.team14.webty.voting.enumerate;
+
+import java.util.Arrays;
+
+import org.team14.webty.common.exception.BusinessException;
+import org.team14.webty.common.exception.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VoteType {
+	AGREE("agree"),
+	DISAGREE("disagree");
+
+	private final String type;
+
+	public static VoteType fromString(String value) {
+		return Arrays.stream(values())
+			.filter(status -> status.type.equalsIgnoreCase(value))
+			.findFirst().orElseThrow(() -> new BusinessException(ErrorCode.RECOMMEND_TYPE_ERROR));
+	}
+}

--- a/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
+++ b/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
@@ -1,0 +1,24 @@
+package org.team14.webty.voting.mapper;
+
+import org.team14.webty.voting.dto.SimilarResponse;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.webtoon.entity.Webtoon;
+
+public class SimilarMapper {
+	public static Similar toEntity(Long userId, String similarWebtoonName, Webtoon webtoon) {
+		return Similar.builder()
+			.userId(userId)
+			.similarWebtoonName(similarWebtoonName)
+			.similarResult(0L)
+			.webtoon(webtoon)
+			.build();
+	}
+
+	public static SimilarResponse toResponse(Similar similar) {
+		return SimilarResponse.builder()
+			.similarId(similar.getSimilarId())
+			.thumbnailUrl(similar.getWebtoon().getThumbnailUrl())
+			.similarResult(similar.getSimilarResult())
+			.build();
+	}
+}

--- a/src/main/java/org/team14/webty/voting/mapper/VoteMapper.java
+++ b/src/main/java/org/team14/webty/voting/mapper/VoteMapper.java
@@ -1,0 +1,16 @@
+package org.team14.webty.voting.mapper;
+
+import org.team14.webty.user.entity.WebtyUser;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.voting.entity.Vote;
+import org.team14.webty.voting.enumerate.VoteType;
+
+public class VoteMapper {
+	public static Vote toEntity(WebtyUser webtyUser, Similar similar, String type) {
+		return Vote.builder()
+			.userId(webtyUser.getUserId())
+			.similar(similar)
+			.voteType(VoteType.fromString(type))
+			.build();
+	}
+}

--- a/src/main/java/org/team14/webty/voting/repository/SimilarRepository.java
+++ b/src/main/java/org/team14/webty/voting/repository/SimilarRepository.java
@@ -1,4 +1,19 @@
 package org.team14.webty.voting.repository;
 
-public interface SimilarRepository {
+import java.util.Optional;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.webtoon.entity.Webtoon;
+
+@Repository
+public interface SimilarRepository extends JpaRepository<Similar, Long> {
+	Boolean existsByWebtoonAndSimilarWebtoonName(Webtoon webtoon, String similarWebtoonName);
+
+	Optional<Similar> findByUserIdAndSimilarId(Long userId, Long similarId);
+
+	Page<Similar> findAllByWebtoon(Webtoon webtoon, Pageable pageable);
 }

--- a/src/main/java/org/team14/webty/voting/repository/VoteRepository.java
+++ b/src/main/java/org/team14/webty/voting/repository/VoteRepository.java
@@ -1,4 +1,23 @@
 package org.team14.webty.voting.repository;
 
-public interface VoteRepository {
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.voting.entity.Vote;
+import org.team14.webty.voting.enumerate.VoteType;
+
+@Repository
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+	Optional<Vote> findBySimilarAndUserId(Similar similar, Long userId);
+
+	Boolean existsByUserIdAndSimilar(Long userId, Similar similar);
+
+	int deleteBySimilarAndUserId(Similar similar, Long userId);
+
+	List<Vote> findAllBySimilar(Similar similar);
+
+	long countBySimilarAndVoteType(Similar similar, VoteType voteType);
 }

--- a/src/main/java/org/team14/webty/voting/service/SimilarService.java
+++ b/src/main/java/org/team14/webty/voting/service/SimilarService.java
@@ -1,0 +1,82 @@
+package org.team14.webty.voting.service;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.team14.webty.common.exception.BusinessException;
+import org.team14.webty.common.exception.ErrorCode;
+import org.team14.webty.security.authentication.AuthWebtyUserProvider;
+import org.team14.webty.security.authentication.WebtyUserDetails;
+import org.team14.webty.user.entity.WebtyUser;
+import org.team14.webty.voting.dto.SimilarResponse;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.voting.mapper.SimilarMapper;
+import org.team14.webty.voting.repository.SimilarRepository;
+import org.team14.webty.voting.repository.VoteRepository;
+import org.team14.webty.webtoon.entity.Webtoon;
+import org.team14.webty.webtoon.repository.WebtoonRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SimilarService {
+	private final SimilarRepository similarRepository;
+	private final WebtoonRepository webtoonRepository;
+	private final AuthWebtyUserProvider authWebtyUserProvider;
+	private final VoteRepository voteRepository;
+
+	// 유사 웹툰 등록
+	@Transactional
+	public Long createSimilar(WebtyUserDetails webtyUserDetails, Long webtoonId, String similarWebtoonName) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+		Webtoon webtoon = webtoonRepository.findById(webtoonId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.WEBTOON_NOT_FOUND));
+		if (similarWebtoonName == null || similarWebtoonName.trim().isEmpty()) {
+			throw new BusinessException(ErrorCode.INVALID_SIMILAR_NAME);
+		}
+		// 이미 등록된 유사 웹툰인지 확인
+		if (similarRepository.existsByWebtoonAndSimilarWebtoonName(webtoon, similarWebtoonName)) {
+			throw new BusinessException(ErrorCode.SIMILAR_DUPLICATION_ERROR);
+		}
+		Similar similar = SimilarMapper.toEntity(webtyUser.getUserId(), similarWebtoonName, webtoon);
+		try {
+			similarRepository.save(similar);
+		} catch (DataIntegrityViolationException e) {
+			// 데이터베이스에서 UNIQUE 제약 조건 위반 발생 시 처리
+			throw new BusinessException(ErrorCode.SIMILAR_DUPLICATION_ERROR);
+		}
+		return similar.getSimilarId();
+	}
+
+	// 유사 웹툰 삭제
+	@Transactional
+	public void deleteSimilar(WebtyUserDetails webtyUserDetails, Long similarId) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+		Similar similar = similarRepository.findByUserIdAndSimilarId(webtyUser.getUserId(),
+				similarId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SIMILAR_NOT_FOUND));
+		voteRepository.deleteAll(voteRepository.findAllBySimilar(similar)); // 연관된 투표내역도 삭제
+		similarRepository.delete(similar);
+	}
+
+	// 유사 리스트 By Webtoon
+	@Transactional(readOnly = true)
+	public Page<SimilarResponse> findAll(Long webtoonId, int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Webtoon webtoon = webtoonRepository.findById(webtoonId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.WEBTOON_NOT_FOUND));
+		Page<Similar> similars = similarRepository.findAllByWebtoon(webtoon, pageable);
+		return similars.map(SimilarMapper::toResponse);
+	}
+
+	@Transactional(readOnly = true)
+	public SimilarResponse getSimilar(Long similarId) {
+		Similar similar = similarRepository.findById(similarId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.SIMILAR_NOT_FOUND));
+		return SimilarMapper.toResponse(similar);
+	}
+}

--- a/src/main/java/org/team14/webty/voting/service/VoteService.java
+++ b/src/main/java/org/team14/webty/voting/service/VoteService.java
@@ -1,4 +1,63 @@
 package org.team14.webty.voting.service;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.team14.webty.common.exception.BusinessException;
+import org.team14.webty.common.exception.ErrorCode;
+import org.team14.webty.security.authentication.AuthWebtyUserProvider;
+import org.team14.webty.security.authentication.WebtyUserDetails;
+import org.team14.webty.user.entity.WebtyUser;
+import org.team14.webty.voting.dto.VoteRequest;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.voting.entity.Vote;
+import org.team14.webty.voting.enumerate.VoteType;
+import org.team14.webty.voting.mapper.VoteMapper;
+import org.team14.webty.voting.repository.SimilarRepository;
+import org.team14.webty.voting.repository.VoteRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
 public class VoteService {
+	private final VoteRepository voteRepository;
+	private final SimilarRepository similarRepository;
+	private final AuthWebtyUserProvider authWebtyUserProvider;
+
+	// 유사 투표
+	@Transactional
+	public Long vote(WebtyUserDetails webtyUserDetails, VoteRequest voteRequest) {
+		WebtyUser webtyUser = authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+		Similar similar = similarRepository.findById(voteRequest.getSimilarId())
+			.orElseThrow(() -> new BusinessException(ErrorCode.SIMILAR_NOT_FOUND));
+		// 중복 투표 방지
+		if (voteRepository.existsByUserIdAndSimilar(webtyUser.getUserId(), similar)) {
+			throw new BusinessException(ErrorCode.VOTE_ALREADY_EXISTS);
+		}
+		Vote vote = VoteMapper.toEntity(webtyUser, similar, voteRequest.getVoteType());
+		voteRepository.save(vote);
+		updateSimilarResult(similar);
+		return vote.getVoteId();
+	}
+
+	// 투표 취소
+	@Transactional
+	public void cancel(WebtyUserDetails webtyUserDetails, Long voteId) {
+		authWebtyUserProvider.getAuthenticatedWebtyUser(webtyUserDetails);
+		Vote vote = voteRepository.findById(voteId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.VOTE_NOT_FOUND));
+		voteRepository.delete(vote);
+		updateSimilarResult(vote.getSimilar());
+	}
+
+	private void updateSimilarResult(Similar similar) {
+		// agree 및 disagree 투표 개수 가져오기
+		long agreeCount = voteRepository.countBySimilarAndVoteType(similar, VoteType.AGREE); // 동의 수
+		long disagreeCount = voteRepository.countBySimilarAndVoteType(similar, VoteType.DISAGREE); // 비동의 수
+
+		// similarResult 업데이트
+		similar.updateSimilarResult(agreeCount - disagreeCount);
+		similarRepository.save(similar);
+	}
+
 }

--- a/src/main/java/org/team14/webty/webtoon/repository/WebtoonRepository.java
+++ b/src/main/java/org/team14/webty/webtoon/repository/WebtoonRepository.java
@@ -1,10 +1,12 @@
 package org.team14.webty.webtoon.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.team14.webty.webtoon.entity.Webtoon;
 import org.team14.webty.webtoon.enumerate.Platform;
@@ -22,4 +24,6 @@ public interface WebtoonRepository extends JpaRepository<Webtoon, Long> {
 		@Param("authors") String authors,
 		@Param("finished") Boolean finished,
 		Pageable pageable);
+
+	Optional<Webtoon> findByWebtoonName(String similarWebtoonName);
 }


### PR DESCRIPTION
유사 웹툰, 등록, 삭제, 조회가 가능하고 등록된 유사 웹툰 동의/비동의 투표 기능을 추가했습니다.
similarResult같은 경우 agree 수 - disagree 수로 간단하게 만들어 놓았습니다.
 테스트 결과 등록,삭제,조회, 유사 웹툰 투표/취소 기능은 동작하는 것을 확인했고 저희가 만들어 놓은 다른 기능들도 문제없이 동작합니다
 
close #136 