### PR TITLE
feat 리뷰 스포일러 처리 컨트롤러

### DIFF
--- a/src/main/java/org/team14/webty/review/controller/ReviewController.java
+++ b/src/main/java/org/team14/webty/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -108,6 +109,7 @@ public class ReviewController {
 		return ResponseEntity.ok(PageMapper.toPageDto(reviewService.searchFeedReviewByTitle(page, size, title)));
 	}
 
+	// 특정 웹툰 ID에 대한 리뷰 페이지 반환
 	@GetMapping("/webtoon/{webtoonId}")
 	public ResponseEntity<PageDto<ReviewItemResponse>> webtoonReviews(
 		@PathVariable(value = "webtoonId") Long webtoonId,
@@ -115,5 +117,13 @@ public class ReviewController {
 		@RequestParam(defaultValue = "10", value = "size") int size
 	){
 		return ResponseEntity.ok(PageMapper.toPageDto(reviewService.searchReviewByWebtoonId(webtoonId,page, size)));
+	}
+
+	// 특정 리뷰 ID 스포일러 처리
+	@PatchMapping("/spoiler/{reviewId}")
+	public ResponseEntity<Void> patchReviewIsSpoiler(
+		@PathVariable(value = "reviewId") Long reviewId) {
+		reviewService.patchReviewIsSpoiler(reviewId);
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/team14/webty/review/entity/Review.java
+++ b/src/main/java/org/team14/webty/review/entity/Review.java
@@ -64,4 +64,7 @@ public class Review {
 		this.updatedAt = LocalDateTime.now();
 	}
 
+	public void patchIsSpoiler() {
+		this.isSpoiler = SpoilerStatus.TRUE;
+	}
 }

--- a/src/main/java/org/team14/webty/review/service/ReviewService.java
+++ b/src/main/java/org/team14/webty/review/service/ReviewService.java
@@ -329,4 +329,12 @@ public class ReviewService {
 			)
 		);
 	}
+
+	@Transactional
+	public void patchReviewIsSpoiler(Long id) {
+		Review review = reviewRepository.findById(id)
+			.orElseThrow(() -> new BusinessException(ErrorCode.REVIEW_NOT_FOUND));
+		review.patchIsSpoiler();
+		reviewRepository.save(review);
+	}
 }

--- a/src/main/java/org/team14/webty/security/config/SecurityConfig.java
+++ b/src/main/java/org/team14/webty/security/config/SecurityConfig.java
@@ -74,7 +74,8 @@ public class SecurityConfig {
 			"/v3/**", "/swagger-ui/**", "/api/logistics",
 			"h2-console/**", "/error", // 테스트 이후 제거할 목록
 			"/webtoons/**", "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc",
-			"/reviews/search", "/similar", "/similar/{id:\\d+}", "/reviews/webtoon/{id:\\d+}"
+			"/reviews/search", "/similar", "/similar/{id:\\d+}", "/reviews/webtoon/{id:\\d+}",
+			"/reviews/spoiler/{id:\\d+}"
 		).requestMatchers(PathRequest.toH2Console());
 	}
 


### PR DESCRIPTION
프론트에서 로그인 여부에 관계없이 특정 리뷰를 스포일러로 반영할 수 있게끔 만들었습니다.

지금은 그냥 요청 한번 들어오면 스포일러 처리가 됩니다.

그런데 만약 신고가 몇개 이상 시 스포일러 처리 이런 부분을 추가하려면

추가테이블이랑 IP기반 처리 등 추가할 게 많을 것 같습니다.