### PR TITLE
test: Implement SimilarControllerTest createSimilar

### DIFF
--- a/src/main/java/org/team14/webty/voting/controller/SimilarController.java
+++ b/src/main/java/org/team14/webty/voting/controller/SimilarController.java
@@ -51,11 +51,7 @@ public class SimilarController {
 		@RequestParam(value = "size", defaultValue = "10") int size,
 		@RequestBody SimilarResponseRequest similarResponseRequest) {
 		return ResponseEntity.ok()
-			.body(PageMapper.toPageDto(similarService.findAll(similarResponseRequest.getWebtoonId(), page, size)));
-	}
-
-	@GetMapping("/{similarId}")
-	public ResponseEntity<SimilarResponse> getSimilar(@PathVariable(value = "similarId") Long similarId) {
-		return ResponseEntity.ok().body(similarService.getSimilar(similarId));
+			.body(
+				PageMapper.toPageDto(similarService.findAll(similarResponseRequest.getTargetWebtoonId(), page, size)));
 	}
 }

--- a/src/main/java/org/team14/webty/voting/controller/SimilarController.java
+++ b/src/main/java/org/team14/webty/voting/controller/SimilarController.java
@@ -44,6 +44,7 @@ public class SimilarController {
 		return ResponseEntity.ok().build();
 	}
 
+	// 유사 웹툰 목록 조회
 	@GetMapping
 	public ResponseEntity<PageDto<SimilarResponse>> getSimilarList(
 		@RequestParam(value = "page", defaultValue = "0") int page,

--- a/src/main/java/org/team14/webty/voting/controller/SimilarController.java
+++ b/src/main/java/org/team14/webty/voting/controller/SimilarController.java
@@ -28,10 +28,12 @@ public class SimilarController {
 
 	// 유사 웹툰 등록
 	@PostMapping("/create")
-	public ResponseEntity<Long> createSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
+	public ResponseEntity<SimilarResponse> createSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestBody SimilarRequest similarRequest) {
-		return ResponseEntity.ok().body(similarService.createSimilar(webtyUserDetails, similarRequest.getWebtoonId(),
-			similarRequest.getSimilarWebtoonName()));
+		return ResponseEntity.ok()
+			.body(similarService.createSimilar(webtyUserDetails,
+				similarRequest.targetWebtoonId(),
+				similarRequest.choiceWebtoonId()));
 	}
 
 	// 유사 웹툰 삭제

--- a/src/main/java/org/team14/webty/voting/dto/SimilarRequest.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarRequest.java
@@ -1,9 +1,6 @@
 package org.team14.webty.voting.dto;
 
-import lombok.Getter;
+import jakarta.validation.constraints.NotNull;
 
-@Getter
-public class SimilarRequest {
-	private Long webtoonId;
-	private String similarWebtoonName;
+public record SimilarRequest(@NotNull Long targetWebtoonId, @NotNull Long choiceWebtoonId) {
 }

--- a/src/main/java/org/team14/webty/voting/dto/SimilarResponse.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarResponse.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Builder
 public class SimilarResponse {
 	private Long similarId;
-	private String thumbnailUrl;
+	private String similarThumbnailUrl;
 	private Long similarResult;
+	private Long similarWebtoonId; // webtoon-detail 페이지 이동 시 필요
 }

--- a/src/main/java/org/team14/webty/voting/dto/SimilarResponseRequest.java
+++ b/src/main/java/org/team14/webty/voting/dto/SimilarResponseRequest.java
@@ -4,5 +4,5 @@ import lombok.Getter;
 
 @Getter
 public class SimilarResponseRequest {
-	private Long webtoonId;
+	private Long targetWebtoonId;
 }

--- a/src/main/java/org/team14/webty/voting/entity/Similar.java
+++ b/src/main/java/org/team14/webty/voting/entity/Similar.java
@@ -23,18 +23,18 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(
 	name = "similar",
-	uniqueConstraints = @UniqueConstraint(columnNames = {"webtoonId", "similarWebtoonName"})
+	uniqueConstraints = @UniqueConstraint(columnNames = {"targetWebtoonId", "similarWebtoonId"})
 )
 public class Similar {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long similarId;
-	private String similarWebtoonName;
+	private Long similarWebtoonId;
 	private Long similarResult;
 	private Long userId;
 	@ManyToOne
-	@JoinColumn(name = "webtoonId")
-	private Webtoon webtoon;
+	@JoinColumn(name = "targetWebtoonId")
+	private Webtoon targetWebtoon;
 
 	public void updateSimilarResult(Long similarResult) {
 		this.similarResult = similarResult;

--- a/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
+++ b/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
@@ -5,20 +5,21 @@ import org.team14.webty.voting.entity.Similar;
 import org.team14.webty.webtoon.entity.Webtoon;
 
 public class SimilarMapper {
-	public static Similar toEntity(Long userId, String similarWebtoonName, Webtoon webtoon) {
+	public static Similar toEntity(Long userId, Long choiceWebtoonId, Webtoon targetWebtoon) {
 		return Similar.builder()
-			.userId(userId)
-			.similarWebtoonName(similarWebtoonName)
+			.similarWebtoonId(choiceWebtoonId)
 			.similarResult(0L)
-			.webtoon(webtoon)
+			.userId(userId)
+			.targetWebtoon(targetWebtoon)
 			.build();
 	}
 
-	public static SimilarResponse toResponse(Similar similar) {
+	public static SimilarResponse toResponse(Similar similar, Webtoon similarWebtoon) {
 		return SimilarResponse.builder()
 			.similarId(similar.getSimilarId())
-			.similarThumbnailUrl(similar.getWebtoon().getThumbnailUrl())
+			.similarThumbnailUrl(similarWebtoon.getThumbnailUrl())
 			.similarResult(similar.getSimilarResult())
+			.similarWebtoonId(similarWebtoon.getWebtoonId())
 			.build();
 	}
 }

--- a/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
+++ b/src/main/java/org/team14/webty/voting/mapper/SimilarMapper.java
@@ -17,7 +17,7 @@ public class SimilarMapper {
 	public static SimilarResponse toResponse(Similar similar) {
 		return SimilarResponse.builder()
 			.similarId(similar.getSimilarId())
-			.thumbnailUrl(similar.getWebtoon().getThumbnailUrl())
+			.similarThumbnailUrl(similar.getWebtoon().getThumbnailUrl())
 			.similarResult(similar.getSimilarResult())
 			.build();
 	}

--- a/src/main/java/org/team14/webty/voting/repository/SimilarRepository.java
+++ b/src/main/java/org/team14/webty/voting/repository/SimilarRepository.java
@@ -11,9 +11,9 @@ import org.team14.webty.webtoon.entity.Webtoon;
 
 @Repository
 public interface SimilarRepository extends JpaRepository<Similar, Long> {
-	Boolean existsByWebtoonAndSimilarWebtoonName(Webtoon webtoon, String similarWebtoonName);
+	Boolean existsByTargetWebtoonAndSimilarWebtoonId(Webtoon targetWebtoon, Long similarWebtoonId);
 
 	Optional<Similar> findByUserIdAndSimilarId(Long userId, Long similarId);
 
-	Page<Similar> findAllByWebtoon(Webtoon webtoon, Pageable pageable);
+	Page<Similar> findAllByTargetWebtoon(Webtoon targetWebtoon, Pageable pageable);
 }

--- a/src/test/java/org/team14/webty/voting/controller/SimilarControllerTest.java
+++ b/src/test/java/org/team14/webty/voting/controller/SimilarControllerTest.java
@@ -1,0 +1,126 @@
+package org.team14.webty.voting.controller;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.team14.webty.security.token.JwtManager;
+import org.team14.webty.user.entity.SocialProvider;
+import org.team14.webty.user.entity.WebtyUser;
+import org.team14.webty.user.enumerate.SocialProviderType;
+import org.team14.webty.user.repository.UserRepository;
+import org.team14.webty.voting.entity.Similar;
+import org.team14.webty.voting.repository.SimilarRepository;
+import org.team14.webty.webtoon.entity.Webtoon;
+import org.team14.webty.webtoon.enumerate.Platform;
+import org.team14.webty.webtoon.repository.WebtoonRepository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {"spring.profiles.active=test"})
+class SimilarControllerTest {
+	@Autowired
+	private WebApplicationContext context;
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private WebtoonRepository webtoonRepository;
+	@Autowired
+	private SimilarRepository similarRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private JwtManager jwtManager;
+	private WebtyUser testUser;
+	private Webtoon testChoiceWebtoon;
+	private Similar testSimilar;
+
+	@BeforeEach
+	void beforeEach() {
+
+		webtoonRepository.deleteAll();
+		similarRepository.deleteAll();
+		userRepository.deleteAll();
+
+		mockMvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.apply(SecurityMockMvcConfigurers.springSecurity())
+			.build();
+
+		testUser = userRepository.save(WebtyUser.builder()
+			.nickname("유사웹툰등록자")
+			.profileImage("similarTestImg")
+			.socialProvider(SocialProvider.builder()
+				.provider(SocialProviderType.KAKAO)
+				.providerId("123456789")
+				.build())
+			.build());
+
+		testChoiceWebtoon = webtoonRepository.save(Webtoon.builder()
+			.webtoonName("테스트 선택 대상 웹툰")
+			.platform(Platform.KAKAO_PAGE)
+			.webtoonLink("www.testChoiceWebtoon")
+			.thumbnailUrl("testChoiceWebtoon.jpg")
+			.authors("testChoiceWebtoonAuthor")
+			.finished(true)
+			.build());
+
+		Webtoon testTargetWebtoon = webtoonRepository.save(Webtoon.builder()
+			.webtoonName("테스트 투표 대상 웹툰")
+			.platform(Platform.KAKAO_PAGE)
+			.webtoonLink("www.testTargetWebtoon")
+			.thumbnailUrl("testTargetWebtoon.jpg")
+			.authors("testTargetWebtoonAuthor")
+			.finished(true)
+			.build());
+
+		testSimilar = similarRepository.save(Similar.builder()
+			.similarWebtoonName("테스트 후보 유사웹툰")
+			.similarResult(1L)
+			.userId(testUser.getUserId())
+			.webtoon(testTargetWebtoon)
+			.build());
+	}
+
+	@Test
+	@DisplayName("유사 등록 테스트")
+	void createSimilar_test() throws Exception {
+		Long testTargetWebtoonId = testSimilar.getWebtoon().getWebtoonId();
+		Long testChoiceWebtoonId = testChoiceWebtoon.getWebtoonId();
+
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		Map<String, Long> requestBody = new HashMap<>();
+		requestBody.put("targetWebtoonId", testTargetWebtoonId);
+		requestBody.put("choiceWebtoonId", testChoiceWebtoonId);
+		String jsonRequest = objectMapper.writeValueAsString(requestBody);
+
+		String accessToken = jwtManager.createAccessToken(testUser.getUserId());
+
+		mockMvc.perform(post("/similar/create")
+				.header("Authorization", "Bearer " + accessToken)
+				.content(jsonRequest)
+				.contentType(MediaType.APPLICATION_JSON)
+				.with(csrf()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.similarThumbnailUrl").value(testChoiceWebtoon.getThumbnailUrl()))
+			.andExpect(jsonPath("$.similarWebtoonId").value(testChoiceWebtoon.getWebtoonId()));
+	}
+}

--- a/src/test/java/org/team14/webty/voting/controller/SimilarControllerTest.java
+++ b/src/test/java/org/team14/webty/voting/controller/SimilarControllerTest.java
@@ -49,8 +49,8 @@ class SimilarControllerTest {
 	@Autowired
 	private JwtManager jwtManager;
 	private WebtyUser testUser;
+	private Webtoon testTargetWebtoon;
 	private Webtoon testChoiceWebtoon;
-	private Similar testSimilar;
 
 	@BeforeEach
 	void beforeEach() {
@@ -73,16 +73,7 @@ class SimilarControllerTest {
 				.build())
 			.build());
 
-		testChoiceWebtoon = webtoonRepository.save(Webtoon.builder()
-			.webtoonName("테스트 선택 대상 웹툰")
-			.platform(Platform.KAKAO_PAGE)
-			.webtoonLink("www.testChoiceWebtoon")
-			.thumbnailUrl("testChoiceWebtoon.jpg")
-			.authors("testChoiceWebtoonAuthor")
-			.finished(true)
-			.build());
-
-		Webtoon testTargetWebtoon = webtoonRepository.save(Webtoon.builder()
+		testTargetWebtoon = webtoonRepository.save(Webtoon.builder()
 			.webtoonName("테스트 투표 대상 웹툰")
 			.platform(Platform.KAKAO_PAGE)
 			.webtoonLink("www.testTargetWebtoon")
@@ -91,18 +82,20 @@ class SimilarControllerTest {
 			.finished(true)
 			.build());
 
-		testSimilar = similarRepository.save(Similar.builder()
-			.similarWebtoonName("테스트 후보 유사웹툰")
-			.similarResult(1L)
-			.userId(testUser.getUserId())
-			.webtoon(testTargetWebtoon)
+		testChoiceWebtoon = webtoonRepository.save(Webtoon.builder()
+			.webtoonName("테스트 선택 대상 웹툰")
+			.platform(Platform.KAKAO_PAGE)
+			.webtoonLink("www.testChoiceWebtoon")
+			.thumbnailUrl("testChoiceWebtoon.jpg")
+			.authors("testChoiceWebtoonAuthor")
+			.finished(true)
 			.build());
 	}
 
 	@Test
 	@DisplayName("유사 등록 테스트")
 	void createSimilar_test() throws Exception {
-		Long testTargetWebtoonId = testSimilar.getWebtoon().getWebtoonId();
+		Long testTargetWebtoonId = testTargetWebtoon.getWebtoonId();
 		Long testChoiceWebtoonId = testChoiceWebtoon.getWebtoonId();
 
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -122,5 +115,18 @@ class SimilarControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.similarThumbnailUrl").value(testChoiceWebtoon.getThumbnailUrl()))
 			.andExpect(jsonPath("$.similarWebtoonId").value(testChoiceWebtoon.getWebtoonId()));
+	}
+
+	@Test
+	@DisplayName("유사 등록 테스트")
+	void deleteSimilar_test() throws Exception {
+		Similar testSimilar = similarRepository.save(Similar.builder()
+			.similarWebtoonId(testChoiceWebtoon.getWebtoonId())
+			.similarResult(0L)
+			.userId(testUser.getUserId())
+			.targetWebtoon(testTargetWebtoon)
+			.build());
+
+		// 작성 예정
 	}
 }


### PR DESCRIPTION
- createSimilar 메소드 테스트 코드 작성
    - 테스트 통과 완료

- Similar entity 수정:
   - targetWebtoon과 similarWebtoonId를 가짐
   - similarWebtoonName -> similarWebtoonId

- createSimilar 메소드 수정:
    - Long 타입이 아닌 SimilarResponse 반환
    - 사용자가 유사 웹툰 등록 시 바로 similarItem을 생성하기 위해 필요한 정보를 SimilarResponse로 한 번에 반환

- similar 관련 요청 및 응답 dto 수정:
    - 요청 dto: 웹툰 이름이 아닌 id로 요청을 받음 (기존 웹툰 검색 후 검색 결과로 받은 id)
    - 응답 dto: similar 웹툰 id 추가 (비교 대상 웹툰 아님), 클릭 시 웹툰 상세 페이지로 이동

- SimilarService 수정:
    - Similar entity 및 dto 수정으로 인한 변경
    - webtoonRepository 호출을 직접 하지않고 webtoonService를 이용하도록 수정 (책임 분리)
    - 필요없는 메소드 삭제

- SimilarRequest class -> record:
    - 더 안전한 불변 객체로 수정

- SimilarController의 getSimilar 메소드 삭제
   - createSimilar 에서 바로 반환하므로, 더이상 필요하지 않아서 삭제

- 나머지 테스트 메소드 구현 필요

<br>

---

close #156

---

Similar 엔티티 수정으로 인해
db에서 Similar 테이블을 삭제해야할 수 있습니다
main 병합 후 오류 발생 시 Similar 테이블 삭제 후 다시 실행해주세요

@segye @yuunha @DayDreaam @Nicholas070 @SafeDrivingPikachu 