### PR TITLE
test: SimilarControllerTest Delete, GetList

### DIFF
--- a/src/main/java/org/team14/webty/security/config/SecurityConfig.java
+++ b/src/main/java/org/team14/webty/security/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -38,13 +39,6 @@ public class SecurityConfig {
 		http.addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 			.authorizeHttpRequests(authorizeRequests ->
 				authorizeRequests
-					// .requestMatchers(HttpMethod.GET, "/webtoons/{id:\\d+}").permitAll()
-					// .requestMatchers(HttpMethod.GET, "/reviews/{id:\\d+}}").permitAll()
-					// .requestMatchers(HttpMethod.GET, "/webtoons/search").permitAll()
-					// .requestMatchers("/reviews/**").permitAll()
-					// .requestMatchers("/logout/kakao", "/user-profile", "/user/**",
-					// 	"/favorite/**") // 로그인 해야 접속 가능한 페이지 목록
-					// .authenticated()
 					.anyRequest() // 나머지
 					.authenticated())
 			.sessionManagement(sessionManagement ->
@@ -71,12 +65,14 @@ public class SecurityConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() { // 스프링 시큐리티를 무시할 페이지 목록 ( = 로그인이 필요없는 페이지 목록)
 		return web -> web.ignoring().requestMatchers(
-			"/v3/**", "/swagger-ui/**", "/api/logistics",
-			"h2-console/**", "/error", // 테스트 이후 제거할 목록
-			"/webtoons/**", "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc",
-			"/reviews/search", "/similar", "/similar/{id:\\d+}", "/reviews/webtoon/{id:\\d+}",
-			"/reviews/spoiler/{id:\\d+}"
-		).requestMatchers(PathRequest.toH2Console());
+				"/v3/**", "/swagger-ui/**", "/api/logistics",
+				"h2-console/**", "/error", // 테스트 이후 제거할 목록
+				"/webtoons/**", "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc",
+				"/reviews/search", "/reviews/webtoon/{id:\\d+}",
+				"/reviews/spoiler/{id:\\d+}"
+			)
+			.requestMatchers(HttpMethod.GET, "/similar")
+			.requestMatchers(PathRequest.toH2Console());
 	}
 
 	@Bean

--- a/src/main/java/org/team14/webty/security/config/SecurityConfig.java
+++ b/src/main/java/org/team14/webty/security/config/SecurityConfig.java
@@ -66,7 +66,7 @@ public class SecurityConfig {
 	public WebSecurityCustomizer webSecurityCustomizer() { // 스프링 시큐리티를 무시할 페이지 목록 ( = 로그인이 필요없는 페이지 목록)
 		return web -> web.ignoring().requestMatchers(
 				"/v3/**", "/swagger-ui/**", "/api/logistics",
-				"h2-console/**", "/error", // 테스트 이후 제거할 목록
+				"h2-console/**", "/error",
 				"/webtoons/**", "/reviews/{id:\\d+}", "/reviews", "/reviews/view-count-desc",
 				"/reviews/search", "/reviews/webtoon/{id:\\d+}",
 				"/reviews/spoiler/{id:\\d+}"

--- a/src/main/java/org/team14/webty/voting/controller/SimilarController.java
+++ b/src/main/java/org/team14/webty/voting/controller/SimilarController.java
@@ -15,7 +15,6 @@ import org.team14.webty.common.mapper.PageMapper;
 import org.team14.webty.security.authentication.WebtyUserDetails;
 import org.team14.webty.voting.dto.SimilarRequest;
 import org.team14.webty.voting.dto.SimilarResponse;
-import org.team14.webty.voting.dto.SimilarResponseRequest;
 import org.team14.webty.voting.service.SimilarService;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,7 @@ public class SimilarController {
 	private final SimilarService similarService;
 
 	// 유사 웹툰 등록
-	@PostMapping("/create")
+	@PostMapping
 	public ResponseEntity<SimilarResponse> createSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@RequestBody SimilarRequest similarRequest) {
 		return ResponseEntity.ok()
@@ -37,7 +36,7 @@ public class SimilarController {
 	}
 
 	// 유사 웹툰 삭제
-	@DeleteMapping("/delete/{similarId}")
+	@DeleteMapping("/{similarId}")
 	public ResponseEntity<Void> deleteSimilar(@AuthenticationPrincipal WebtyUserDetails webtyUserDetails,
 		@PathVariable(value = "similarId") Long similarId) {
 		similarService.deleteSimilar(webtyUserDetails, similarId);
@@ -49,9 +48,9 @@ public class SimilarController {
 	public ResponseEntity<PageDto<SimilarResponse>> getSimilarList(
 		@RequestParam(value = "page", defaultValue = "0") int page,
 		@RequestParam(value = "size", defaultValue = "10") int size,
-		@RequestBody SimilarResponseRequest similarResponseRequest) {
+		@RequestParam("targetWebtoonId") Long targetWebtoonId) {
 		return ResponseEntity.ok()
 			.body(
-				PageMapper.toPageDto(similarService.findAll(similarResponseRequest.getTargetWebtoonId(), page, size)));
+				PageMapper.toPageDto(similarService.findAll(targetWebtoonId, page, size)));
 	}
 }


### PR DESCRIPTION
- SimilarControllerTest 구현:
    - deleteSimilar_test 추가
    - getSimilarList_test 추가
    - createSimilar_test 수정 (controller의 요청 url 변경에 따라 수정)

- SimilarController 수정:
    - RESTful 디자인 원칙을 지키고자 수정함
    - url에 delete, create 를 포함하지 않도록 제거 (의미 중복)
    - get 요청에 requestbody을 사용하지 않도록 수정

- SecurityConfig 수정:
    - similar 요청 ignore 설정 수정
    - 필요없는 주석 제거

---

참고글:
- [GET에 body를 사용하지 않는 이유](https://velog.io/@sejin3319/HTTP-HTTP-Method)
- [좋은 restAPI 설계 방법](https://sanghaklee.tistory.com/57)


---

close #155 
